### PR TITLE
Update to es8

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -7,8 +7,8 @@ on:
 
 env:
   IMAGE_NAME: es-with-sudachi
-  ELASTIC_VER: 7.17.9
-  SUDACHI_PLUGIN_VER: 3.0.1
+  ELASTIC_VER: 8.8.1
+  SUDACHI_PLUGIN_VER: 3.1.0
 
 jobs:
   build-image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG SUDACHI_PLUGIN_VER
 
 RUN apk --no-cache --update add curl
 
-RUN curl -OL https://github.com/WorksApplications/elasticsearch-sudachi/releases/download/v${SUDACHI_PLUGIN_VER}/analysis-sudachi-${ELASTIC_VER}-${SUDACHI_PLUGIN_VER}.zip
+RUN curl -OL https://github.com/WorksApplications/elasticsearch-sudachi/releases/download/v${SUDACHI_PLUGIN_VER}/elasticsearch-${ELASTIC_VER}-analysis-sudachi-${SUDACHI_PLUGIN_VER}.zip
 
 
 FROM --platform=$BUILDPLATFORM alpine:latest AS dict-downloader
@@ -33,9 +33,9 @@ FROM elasticsearch:${ELASTIC_VER}
 ARG ELASTIC_VER
 ARG SUDACHI_PLUGIN_VER
 
-COPY --from=plugin-downloader /work/analysis-sudachi-${ELASTIC_VER}-${SUDACHI_PLUGIN_VER}.zip .
-RUN bin/elasticsearch-plugin install file://$(pwd)/analysis-sudachi-${ELASTIC_VER}-${SUDACHI_PLUGIN_VER}.zip && \
-    rm analysis-sudachi-${ELASTIC_VER}-${SUDACHI_PLUGIN_VER}.zip
+COPY --from=plugin-downloader /work/elasticsearch-${ELASTIC_VER}-analysis-sudachi-${SUDACHI_PLUGIN_VER}.zip .
+RUN bin/elasticsearch-plugin install file://$(pwd)/elasticsearch-${ELASTIC_VER}-analysis-sudachi-${SUDACHI_PLUGIN_VER}.zip && \
+    rm elasticsearch-${ELASTIC_VER}-analysis-sudachi-${SUDACHI_PLUGIN_VER}.zip
 
 COPY --from=dict-downloader --chown=elasticsearch:root /work/sudachi-dictionary-*/*.dic ./config/sudachi/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG ELASTIC_VER
 ARG SUDACHI_PLUGIN_VER
-ARG SUDACHI_DICT_VER=20230110
+# http://sudachi.s3-website-ap-northeast-1.amazonaws.com/sudachidict/
+ARG SUDACHI_DICT_VER=20230927
 
 
 FROM --platform=$BUILDPLATFORM alpine:latest AS plugin-downloader


### PR DESCRIPTION
ビルドのテスト
`docker buildx build -t ghcr.io/traptitech/es-with-sudachi:8.8.1-3.1.0 --build-arg ELASTIC_VER=8.8.1 --build-arg SUDACHI_PLUGIN_VER=3.1.0 --platform linux/amd64,linux/arm64 .`

closes #5